### PR TITLE
set up issue caching mechansim

### DIFF
--- a/internal/issuecache/key.go
+++ b/internal/issuecache/key.go
@@ -1,0 +1,70 @@
+package issuecache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dhth/punchout/internal/config"
+)
+
+const keyFormatNamespace = "punchout-issue-cache-v1"
+
+type cloudInstallationKeyInputs struct {
+	Type     string `json:"type"`
+	URL      string `json:"url"`
+	Username string `json:"username"`
+	Token    string `json:"token"`
+}
+
+type onPremiseInstallationKeyInputs struct {
+	Type  string `json:"type"`
+	URL   string `json:"url"`
+	Token string `json:"token"`
+}
+
+type installationKeyInput interface {
+	cloudInstallationKeyInputs | onPremiseInstallationKeyInputs
+}
+
+type cacheKeyInputs[T installationKeyInput] struct {
+	Namespace    string `json:"namespace"`
+	JQL          string `json:"jql"`
+	Installation T      `json:"installation"`
+}
+
+func deriveKey(installation config.JiraInstallation, jql string) (string, error) {
+	switch installation := installation.(type) {
+	case config.CloudInstallation:
+		return deriveKeyFromInputs(jql, cloudInstallationKeyInputs{
+			Type:     config.JiraInstallationTypeCloud,
+			URL:      installation.URL,
+			Username: installation.Username,
+			Token:    installation.Token,
+		})
+	case config.OnPremiseInstallation:
+		return deriveKeyFromInputs(jql, onPremiseInstallationKeyInputs{
+			Type:  config.JiraInstallationTypeOnPremise,
+			URL:   installation.URL,
+			Token: installation.Token,
+		})
+	default:
+		return "", fmt.Errorf("unsupported JIRA installation type %T", installation)
+	}
+}
+
+func deriveKeyFromInputs[T installationKeyInput](jql string, installation T) (string, error) {
+	encodedKeyInputs, err := json.Marshal(cacheKeyInputs[T]{
+		Namespace:    keyFormatNamespace,
+		JQL:          jql,
+		Installation: installation,
+	})
+	if err != nil {
+		return "", fmt.Errorf("couldn't encode issue cache key inputs: %w", err)
+	}
+
+	keyHash := sha256.Sum256(encodedKeyInputs)
+
+	return hex.EncodeToString(keyHash[:]), nil
+}

--- a/internal/issuecache/key_test.go
+++ b/internal/issuecache/key_test.go
@@ -1,0 +1,210 @@
+package issuecache
+
+import (
+	"testing"
+
+	"github.com/dhth/punchout/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveKeyIsDeterministic(t *testing.T) {
+	cases := []struct {
+		name         string
+		installation config.JiraInstallation
+	}{
+		{
+			name: "cloud installation",
+			installation: config.CloudInstallation{
+				URL:      "https://cloud.jira.example.com",
+				Username: "cloud-user@example.com",
+				Token:    "cloud-token",
+			},
+		},
+		{
+			name: "on-premise installation",
+			installation: config.OnPremiseInstallation{
+				URL:   "https://jira.example.com",
+				Token: "on-premise-token",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reference, err := deriveKey(tc.installation, "project = TEST")
+			require.NoError(t, err)
+
+			for i := range 10 {
+				other, err := deriveKey(tc.installation, "project = TEST")
+				require.NoError(t, err, "deriveKey failed in iteration #%d", i)
+				assert.Equal(t, reference, other, "computed value in iteration #%d wasn't equal to the reference", i)
+			}
+		})
+	}
+}
+
+func TestDeriveKeyChangesWithCloudInputs(t *testing.T) {
+	baseInstallation := config.CloudInstallation{
+		URL:      "https://cloud.jira.example.com",
+		Username: "cloud-user@example.com",
+		Token:    "cloud-token",
+	}
+	baseJQL := "project = TEST"
+
+	baseKey, err := deriveKey(baseInstallation, baseJQL)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name         string
+		installation config.CloudInstallation
+		jql          string
+	}{
+		{
+			name: "URL changes",
+			installation: config.CloudInstallation{
+				URL:      "https://other-cloud.jira.example.com",
+				Username: baseInstallation.Username,
+				Token:    baseInstallation.Token,
+			},
+			jql: baseJQL,
+		},
+		{
+			name: "username changes",
+			installation: config.CloudInstallation{
+				URL:      baseInstallation.URL,
+				Username: "other-cloud-user@example.com",
+				Token:    baseInstallation.Token,
+			},
+			jql: baseJQL,
+		},
+		{
+			name: "token changes",
+			installation: config.CloudInstallation{
+				URL:      baseInstallation.URL,
+				Username: baseInstallation.Username,
+				Token:    "other-cloud-token",
+			},
+			jql: baseJQL,
+		},
+		{
+			name:         "JQL changes",
+			installation: baseInstallation,
+			jql:          "project = OTHER",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := deriveKey(tc.installation, tc.jql)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseKey, key)
+		})
+	}
+}
+
+func TestDeriveKeyChangesWithOnPremiseInputs(t *testing.T) {
+	baseInstallation := config.OnPremiseInstallation{
+		URL:   "https://jira.example.com",
+		Token: "on-premise-token",
+	}
+	baseJQL := "project = TEST"
+
+	baseKey, err := deriveKey(baseInstallation, baseJQL)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name         string
+		installation config.OnPremiseInstallation
+		jql          string
+	}{
+		{
+			name: "URL changes",
+			installation: config.OnPremiseInstallation{
+				URL:   "https://other-jira.example.com",
+				Token: baseInstallation.Token,
+			},
+			jql: baseJQL,
+		},
+		{
+			name: "token changes",
+			installation: config.OnPremiseInstallation{
+				URL:   baseInstallation.URL,
+				Token: "other-on-premise-token",
+			},
+			jql: baseJQL,
+		},
+		{
+			name:         "JQL changes",
+			installation: baseInstallation,
+			jql:          "project = OTHER",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := deriveKey(tc.installation, tc.jql)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseKey, key)
+		})
+	}
+}
+
+func TestDeriveKeySeparatesInstallationTypes(t *testing.T) {
+	jiraURL := "https://jira.example.com"
+	token := "shared-token"
+	jql := "project = TEST"
+
+	cloudKey, err := deriveKey(config.CloudInstallation{
+		URL:      jiraURL,
+		Username: "user@example.com",
+		Token:    token,
+	}, jql)
+	require.NoError(t, err)
+
+	onPremiseKey, err := deriveKey(config.OnPremiseInstallation{
+		URL:   jiraURL,
+		Token: token,
+	}, jql)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, cloudKey, onPremiseKey)
+}
+
+func TestDeriveKeyReturnsLowercaseSHA256(t *testing.T) {
+	cases := []struct {
+		name         string
+		installation config.JiraInstallation
+	}{
+		{
+			name: "cloud installation",
+			installation: config.CloudInstallation{
+				URL:      "https://cloud.jira.example.com",
+				Username: "cloud-user@example.com",
+				Token:    "cloud-token",
+			},
+		},
+		{
+			name: "on-premise installation",
+			installation: config.OnPremiseInstallation{
+				URL:   "https://jira.example.com",
+				Token: "on-premise-token",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := deriveKey(tc.installation, "project = TEST")
+			require.NoError(t, err)
+			assert.Regexp(t, `^[0-9a-f]{64}$`, key)
+		})
+	}
+}
+
+func TestDeriveKeyRejectsUnsupportedInstallation(t *testing.T) {
+	_, err := deriveKey(nil, "project = TEST")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported JIRA installation type")
+}

--- a/internal/issuecache/store.go
+++ b/internal/issuecache/store.go
@@ -21,18 +21,18 @@ type Snapshot struct {
 	FetchedAt time.Time      `json:"fetched_at"`
 }
 
-func NewStore(userCacheDir string, installation config.JiraInstallation, jql string) (*Store, error) {
+func NewStore(userCacheDir string, installation config.JiraInstallation, jql string) (Store, error) {
 	key, err := deriveKey(installation, jql)
 	if err != nil {
-		return nil, err
+		return Store{}, err
 	}
 
-	return &Store{
+	return Store{
 		filePath: filepath.Join(userCacheDir, "punchout", "issues", key+".json"),
 	}, nil
 }
 
-func (s *Store) Load() (Snapshot, error) {
+func (s Store) Load() (Snapshot, error) {
 	contents, err := os.ReadFile(s.filePath)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("couldn't read issue cache file: %w", err)
@@ -52,7 +52,7 @@ func (s *Store) Load() (Snapshot, error) {
 	return snapshot, nil
 }
 
-func (s *Store) Save(snapshot Snapshot) error {
+func (s Store) Save(snapshot Snapshot) error {
 	if snapshot.FetchedAt.IsZero() {
 		return errors.New("fetched-at timestamp is zero")
 	}

--- a/internal/issuecache/store.go
+++ b/internal/issuecache/store.go
@@ -1,0 +1,95 @@
+package issuecache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dhth/punchout/internal/config"
+	"github.com/dhth/punchout/internal/domain"
+)
+
+type Store struct {
+	filePath string
+}
+
+type Snapshot struct {
+	Issues    []domain.Issue `json:"issues"`
+	FetchedAt time.Time      `json:"fetched_at"`
+}
+
+func NewStore(userCacheDir string, installation config.JiraInstallation, jql string) (*Store, error) {
+	key, err := deriveKey(installation, jql)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		filePath: filepath.Join(userCacheDir, "punchout", "issues", key+".json"),
+	}, nil
+}
+
+func (s *Store) Load() (Snapshot, error) {
+	contents, err := os.ReadFile(s.filePath)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("couldn't read issue cache file: %w", err)
+	}
+
+	var snapshot Snapshot
+	if err := json.Unmarshal(contents, &snapshot); err != nil {
+		return Snapshot{}, fmt.Errorf("couldn't decode issue cache: %w", err)
+	}
+	if snapshot.Issues == nil {
+		return Snapshot{}, errors.New("issues are missing or null in the cache file")
+	}
+	if snapshot.FetchedAt.IsZero() {
+		return Snapshot{}, errors.New("cache file has a zero fetched-at timestamp")
+	}
+
+	return snapshot, nil
+}
+
+func (s *Store) Save(snapshot Snapshot) error {
+	if snapshot.FetchedAt.IsZero() {
+		return errors.New("fetched-at timestamp is zero")
+	}
+
+	if snapshot.Issues == nil {
+		snapshot.Issues = []domain.Issue{}
+	}
+
+	encodedSnapshot, err := json.Marshal(snapshot)
+	if err != nil {
+		return fmt.Errorf("couldn't encode issue cache snapshot: %w", err)
+	}
+
+	cacheDir := filepath.Dir(s.filePath)
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return fmt.Errorf("couldn't create issue cache directory: %w", err)
+	}
+
+	tempFile, err := os.CreateTemp(cacheDir, ".issues-*.tmp")
+	if err != nil {
+		return fmt.Errorf("couldn't create temporary issue cache file: %w", err)
+	}
+	tempFilePath := tempFile.Name()
+	defer func() {
+		_ = os.Remove(tempFilePath)
+	}()
+
+	if _, err := tempFile.Write(encodedSnapshot); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("couldn't write issue cache snapshot: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("couldn't close temporary issue cache file: %w", err)
+	}
+	if err := os.Rename(tempFilePath, s.filePath); err != nil {
+		return fmt.Errorf("couldn't replace issue cache file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/issuecache/store_test.go
+++ b/internal/issuecache/store_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestStoreRoundTripsSnapshot(t *testing.T) {
-	store := &Store{
+	store := Store{
 		filePath: filepath.Join(t.TempDir(), "issues", "issues.json"),
 	}
 	expected := Snapshot{
@@ -44,7 +44,7 @@ func TestStoreRoundTripsSnapshot(t *testing.T) {
 }
 
 func TestStoreNormalizesNilIssues(t *testing.T) {
-	store := &Store{
+	store := Store{
 		filePath: filepath.Join(t.TempDir(), "issues", "issues.json"),
 	}
 	snapshot := Snapshot{
@@ -61,7 +61,7 @@ func TestStoreNormalizesNilIssues(t *testing.T) {
 }
 
 func TestStoreRejectsSnapshotWithZeroFetchedAt(t *testing.T) {
-	store := &Store{
+	store := Store{
 		filePath: filepath.Join(t.TempDir(), "issues", "issues.json"),
 	}
 
@@ -116,7 +116,7 @@ func TestStoreRejectsInvalidCacheFiles(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			store := &Store{
+			store := Store{
 				filePath: filepath.Join(t.TempDir(), "issues.json"),
 			}
 			err := os.WriteFile(store.filePath, []byte(tc.contents), 0o600)
@@ -130,7 +130,7 @@ func TestStoreRejectsInvalidCacheFiles(t *testing.T) {
 }
 
 func TestStoreReplacesExistingSnapshot(t *testing.T) {
-	store := &Store{
+	store := Store{
 		filePath: filepath.Join(t.TempDir(), "issues", "issues.json"),
 	}
 	initial := Snapshot{

--- a/internal/issuecache/store_test.go
+++ b/internal/issuecache/store_test.go
@@ -1,0 +1,170 @@
+package issuecache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dhth/punchout/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreRoundTripsSnapshot(t *testing.T) {
+	store := &Store{
+		filePath: filepath.Join(t.TempDir(), "issues", "issues.json"),
+	}
+	expected := Snapshot{
+		Issues: []domain.Issue{
+			{
+				IssueKey:        "TEST-123",
+				IssueType:       "Task",
+				Summary:         "Implement issue caching",
+				Assignee:        "user@example.com",
+				Status:          "In Progress",
+				AggSecondsSpent: 3600,
+			},
+			{
+				IssueKey:  "TEST-456",
+				IssueType: "Bug",
+				Summary:   "Fix cache loading",
+				Status:    "Open",
+			},
+		},
+		FetchedAt: time.Date(2026, time.August, 1, 12, 30, 0, 0, time.UTC),
+	}
+
+	err := store.Save(expected)
+	require.NoError(t, err, "saving snapshot failed")
+
+	actual, err := store.Load()
+	require.NoError(t, err, "loading snapshot failed")
+	assert.Equal(t, expected, actual)
+}
+
+func TestStoreNormalizesNilIssues(t *testing.T) {
+	store := &Store{
+		filePath: filepath.Join(t.TempDir(), "issues", "issues.json"),
+	}
+	snapshot := Snapshot{
+		FetchedAt: time.Date(2026, time.August, 1, 12, 30, 0, 0, time.UTC),
+	}
+
+	err := store.Save(snapshot)
+	require.NoError(t, err, "saving snapshot failed")
+
+	actual, err := store.Load()
+	require.NoError(t, err, "loading snapshot failed")
+	assert.NotNil(t, actual.Issues)
+	assert.Empty(t, actual.Issues)
+}
+
+func TestStoreRejectsSnapshotWithZeroFetchedAt(t *testing.T) {
+	store := &Store{
+		filePath: filepath.Join(t.TempDir(), "issues", "issues.json"),
+	}
+
+	err := store.Save(Snapshot{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetched-at timestamp is zero")
+}
+
+func TestStoreRejectsInvalidCacheFiles(t *testing.T) {
+	cases := []struct {
+		name          string
+		contents      string
+		expectedError string
+	}{
+		{
+			name:          "JSON is malformed",
+			contents:      `{`,
+			expectedError: "couldn't decode issue cache",
+		},
+		{
+			name:          "issues are missing",
+			contents:      `{"fetched_at":"2026-08-01T12:30:00Z"}`,
+			expectedError: "issues are missing or null",
+		},
+		{
+			name:          "issues are null",
+			contents:      `{"issues":null,"fetched_at":"2026-08-01T12:30:00Z"}`,
+			expectedError: "issues are missing or null",
+		},
+		{
+			name:          "fetched-at timestamp is missing",
+			contents:      `{"issues":[]}`,
+			expectedError: "zero fetched-at timestamp",
+		},
+		{
+			name:          "fetched-at timestamp is null",
+			contents:      `{"issues":[],"fetched_at":null}`,
+			expectedError: "zero fetched-at timestamp",
+		},
+		{
+			name:          "fetched-at timestamp is zero",
+			contents:      `{"issues":[],"fetched_at":"0001-01-01T00:00:00Z"}`,
+			expectedError: "zero fetched-at timestamp",
+		},
+		{
+			name:          "fetched-at timestamp is malformed",
+			contents:      `{"issues":[],"fetched_at":"not-a-timestamp"}`,
+			expectedError: "couldn't decode issue cache",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &Store{
+				filePath: filepath.Join(t.TempDir(), "issues.json"),
+			}
+			err := os.WriteFile(store.filePath, []byte(tc.contents), 0o600)
+			require.NoError(t, err, "writing cache file failed")
+
+			_, err = store.Load()
+			require.Error(t, err, "loading should've failed")
+			assert.Contains(t, err.Error(), tc.expectedError)
+		})
+	}
+}
+
+func TestStoreReplacesExistingSnapshot(t *testing.T) {
+	store := &Store{
+		filePath: filepath.Join(t.TempDir(), "issues", "issues.json"),
+	}
+	initial := Snapshot{
+		Issues: []domain.Issue{
+			{
+				IssueKey:  "TEST-123",
+				IssueType: "Task",
+				Summary:   "Initial issue",
+				Status:    "Open",
+			},
+		},
+		FetchedAt: time.Date(2026, time.August, 1, 12, 30, 0, 0, time.UTC),
+	}
+	replacement := Snapshot{
+		Issues: []domain.Issue{
+			{
+				IssueKey:        "TEST-456",
+				IssueType:       "Bug",
+				Summary:         "Replacement issue",
+				Assignee:        "user@example.com",
+				Status:          "In Progress",
+				AggSecondsSpent: 1800,
+			},
+		},
+		FetchedAt: time.Date(2026, time.August, 1, 13, 30, 0, 0, time.UTC),
+	}
+
+	err := store.Save(initial)
+	require.NoError(t, err, "saving initial snapshot failed")
+
+	err = store.Save(replacement)
+	require.NoError(t, err, "saving replacement snapshot failed")
+
+	actual, err := store.Load()
+	require.NoError(t, err, "loading snapshot failed")
+	assert.Equal(t, replacement, actual)
+}


### PR DESCRIPTION
Introduce a disposable JSON-backed issue cache under the user cache
directory, separate from the worklog database. Cache files are selected
by a namespaced SHA-256 key derived from the resolved Jira installation,
credentials, and JQL, preventing results from being reused across
different access contexts or queries without exposing those inputs in
the filename.

The store owns filesystem mechanics rather than caching policy. The TUI
will receive it as a dependency and decide when to load cached data,
bootstrap from Jira, and write through after successful fetches.

Sets up foundations for https://github.com/dhth/punchout/issues/127.
