### PR TITLE
start saving issues to cache

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/dhth/punchout/internal/config"
+	"github.com/dhth/punchout/internal/issuecache"
 	"github.com/dhth/punchout/internal/mcp"
 	pers "github.com/dhth/punchout/internal/persistence"
 	svc "github.com/dhth/punchout/internal/service"
@@ -24,6 +25,7 @@ const (
 var (
 	errCouldntGetHomeDir   = errors.New("couldn't get your home directory")
 	errCouldntGetConfigDir = errors.New("couldn't get your config directory")
+	errCouldntGetCacheDir  = errors.New("couldn't get your cache directory")
 	errConfigFilePathEmpty = errors.New("config file path cannot be empty")
 	errDBPathEmpty         = errors.New("db file path cannot be empty")
 	errTimeDeltaIncorrect  = errors.New("couldn't convert time delta to a number")
@@ -132,6 +134,15 @@ func NewRootCommand() (*cobra.Command, error) {
 				return nil
 			}
 
+			userCacheDir, err := os.UserCacheDir()
+			if err != nil {
+				return fmt.Errorf("%w: %s", errCouldntGetCacheDir, err.Error())
+			}
+			issueStore, err := issuecache.NewStore(userCacheDir, appCfg.Jira.Installation, appCfg.Jira.Options.JQL)
+			if err != nil {
+				return fmt.Errorf("couldn't initialize issue cache: %w", err)
+			}
+
 			db, err = pers.GetDB(dbPathFull)
 			if err != nil {
 				return err
@@ -142,7 +153,10 @@ func NewRootCommand() (*cobra.Command, error) {
 				return err
 			}
 
-			return ui.RenderUI(db, jiraSvc, appCfg.Jira.Options)
+			return ui.RenderUI(db, jiraSvc, issueStore, ui.Options{
+				Jira:              appCfg.Jira.Options,
+				UseCacheOnStartup: true,
+			})
 		},
 	}
 

--- a/internal/ui/cmds.go
+++ b/internal/ui/cmds.go
@@ -10,6 +10,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	d "github.com/dhth/punchout/internal/domain"
+	"github.com/dhth/punchout/internal/issuecache"
 	pers "github.com/dhth/punchout/internal/persistence"
 
 	_ "modernc.org/sqlite" // sqlite driver
@@ -213,9 +214,21 @@ func updateSyncStatusForEntry(db *sql.DB, entry d.WorklogEntry, index int, fallb
 
 func (m Model) fetchJIRAIssues() tea.Cmd {
 	return func() tea.Msg {
-		issues, err := m.jiraSvc.GetIssues(m.jiraOpts.JQL)
+		issues, err := m.jiraSvc.GetIssues(m.opts.Jira.JQL)
+		if err != nil {
+			return issuesFetchedFromJIRA{err: err}
+		}
 
-		return issuesFetchedFromJIRA{issues, err}
+		return issuesFetchedFromJIRA{
+			issues:    issues,
+			fetchedAt: time.Now(),
+		}
+	}
+}
+
+func (m Model) saveIssuesToCache(snapshot issuecache.Snapshot) tea.Cmd {
+	return func() tea.Msg {
+		return issuesSavedToCache{err: m.issueStore.Save(snapshot)}
 	}
 }
 
@@ -227,14 +240,14 @@ func (m Model) syncWorklogWithJIRA(entry d.WorklogEntry, index int) tea.Cmd {
 		}
 
 		var comment string
-		if entry.NeedsComment() && m.jiraOpts.FallbackComment != nil {
-			comment = *m.jiraOpts.FallbackComment
+		if entry.NeedsComment() && m.opts.Jira.FallbackComment != nil {
+			comment = *m.opts.Jira.FallbackComment
 			fallbackCmtUsed = true
 		} else if entry.Comment != nil {
 			comment = *entry.Comment
 		}
 
-		err := m.jiraSvc.SyncWLToJIRA(context.TODO(), entry, comment, m.jiraOpts.TimeDeltaMins)
+		err := m.jiraSvc.SyncWLToJIRA(context.TODO(), entry, comment, m.opts.Jira.TimeDeltaMins)
 		return wLSyncedToJIRA{index, entry, fallbackCmtUsed, err}
 	}
 }

--- a/internal/ui/handle.go
+++ b/internal/ui/handle.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	d "github.com/dhth/punchout/internal/domain"
+	"github.com/dhth/punchout/internal/issuecache"
 	pers "github.com/dhth/punchout/internal/persistence"
 )
 
@@ -550,7 +551,22 @@ func (m *Model) handleIssuesFetchedFromJIRAMsg(msg issuesFetchedFromJIRA) tea.Cm
 	m.issueList.Styles.Title = m.issueList.Styles.Title.Background(lipgloss.Color(issueListColor))
 	m.issuesFetched = true
 
-	return fetchActiveStatus(m.db, 0)
+	return tea.Batch(
+		fetchActiveStatus(m.db, 0),
+		m.saveIssuesToCache(issuecache.Snapshot{
+			Issues:    msg.issues,
+			FetchedAt: msg.fetchedAt,
+		}),
+	)
+}
+
+func (m *Model) handleIssuesSavedToCacheMsg(msg issuesSavedToCache) {
+	if msg.err == nil {
+		return
+	}
+
+	m.message = fmt.Sprintf("error saving issues to cache: %s", msg.err.Error())
+	m.messages = append(m.messages, m.message)
 }
 
 func (m *Model) handleManualEntryInsertedInDBMsg(msg manualWLInsertedInDB) tea.Cmd {
@@ -594,7 +610,7 @@ func (m *Model) handleWLEntriesFetchedFromDBMsg(msg wLEntriesFetchedFromDB) {
 	var secsSpent int
 	for i, e := range msg.entries {
 		secsSpent += e.SecsSpent()
-		e.FallbackComment = m.jiraOpts.FallbackComment
+		e.FallbackComment = m.opts.Jira.FallbackComment
 		items[i] = list.Item(e)
 	}
 	m.worklogList.SetItems(items)
@@ -698,7 +714,7 @@ func (m *Model) handleWLSyncedToJIRAMsg(msg wLSyncedToJIRA) tea.Cmd {
 	msg.entry.Synced = true
 	msg.entry.SyncInProgress = false
 	if msg.fallbackCommentUsed {
-		msg.entry.Comment = m.jiraOpts.FallbackComment
+		msg.entry.Comment = m.opts.Jira.FallbackComment
 	}
 	m.worklogList.SetItem(msg.index, msg.entry)
 	return updateSyncStatusForEntry(m.db, msg.entry, msg.index, msg.fallbackCommentUsed)

--- a/internal/ui/initial.go
+++ b/internal/ui/initial.go
@@ -6,12 +6,18 @@ import (
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/lipgloss/v2"
-	"github.com/dhth/punchout/internal/config"
 	d "github.com/dhth/punchout/internal/domain"
+	"github.com/dhth/punchout/internal/issuecache"
 	svc "github.com/dhth/punchout/internal/service"
 )
 
-func InitialModel(db *sql.DB, jiraSvc svc.Jira, jiraOpts config.JiraOptions, debug bool) Model {
+func InitialModel(
+	db *sql.DB,
+	jiraSvc svc.Jira,
+	issueStore issuecache.Store,
+	opts Options,
+	debug bool,
+) Model {
 	var stackItems []list.Item
 	var worklogListItems []list.Item
 	var syncedWorklogListItems []list.Item
@@ -38,7 +44,8 @@ func InitialModel(db *sql.DB, jiraSvc svc.Jira, jiraOpts config.JiraOptions, deb
 	m := Model{
 		db:                db,
 		jiraSvc:           jiraSvc,
-		jiraOpts:          jiraOpts,
+		issueStore:        issueStore,
+		opts:              opts,
 		issueList:         list.New(stackItems, newItemDelegate(lipgloss.Color(issueListColor)), listWidth, 0),
 		issueMap:          make(map[string]*d.Issue),
 		issueIndexMap:     make(map[string]int),

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/dhth/punchout/internal/config"
 	d "github.com/dhth/punchout/internal/domain"
+	"github.com/dhth/punchout/internal/issuecache"
 	svc "github.com/dhth/punchout/internal/service"
 )
 
@@ -59,12 +60,18 @@ const (
 	timeOnlyFormat = "15:04"
 )
 
+type Options struct {
+	Jira              config.JiraOptions
+	UseCacheOnStartup bool
+}
+
 type Model struct {
 	activeView            stateView
 	lastView              stateView
 	db                    *sql.DB
 	jiraSvc               svc.Jira
-	jiraOpts              config.JiraOptions
+	issueStore            issuecache.Store
+	opts                  Options
 	issueList             list.Model
 	issueMap              map[string]*d.Issue
 	issueIndexMap         map[string]int

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -70,8 +70,13 @@ type wLSyncUpdatedInDB struct {
 }
 
 type issuesFetchedFromJIRA struct {
-	issues []d.Issue
-	err    error
+	issues    []d.Issue
+	fetchedAt time.Time
+	err       error
+}
+
+type issuesSavedToCache struct {
+	err error
 }
 
 type wLSyncedToJIRA struct {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -5,11 +5,16 @@ import (
 	"os"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/dhth/punchout/internal/config"
+	"github.com/dhth/punchout/internal/issuecache"
 	svc "github.com/dhth/punchout/internal/service"
 )
 
-func RenderUI(db *sql.DB, jiraSvc svc.Jira, jiraOpts config.JiraOptions) error {
+func RenderUI(
+	db *sql.DB,
+	jiraSvc svc.Jira,
+	issueStore issuecache.Store,
+	opts Options,
+) error {
 	debug := os.Getenv("DEBUG") == "1"
 	if debug {
 		f, err := tea.LogToFile("debug.log", "debug")
@@ -19,7 +24,7 @@ func RenderUI(db *sql.DB, jiraSvc svc.Jira, jiraOpts config.JiraOptions) error {
 		defer f.Close()
 	}
 
-	p := tea.NewProgram(InitialModel(db, jiraSvc, jiraOpts, debug))
+	p := tea.NewProgram(InitialModel(db, jiraSvc, issueStore, opts, debug))
 	if _, err := p.Run(); err != nil {
 		return err
 	}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -232,6 +232,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if handleCmd != nil {
 			cmds = append(cmds, handleCmd)
 		}
+	case issuesSavedToCache:
+		m.handleIssuesSavedToCacheMsg(msg)
 	case manualWLInsertedInDB:
 		handleCmd := m.handleManualEntryInsertedInDBMsg(msg)
 		if handleCmd != nil {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -34,7 +34,7 @@ func (m Model) View() tea.View {
 	var activeMsg string
 
 	var fallbackCommentMsg string
-	if m.jiraOpts.FallbackComment != nil {
+	if m.opts.Jira.FallbackComment != nil {
 		fallbackCommentMsg = " (a fallback is configured)"
 	}
 


### PR DESCRIPTION
Construct the issue cache at the command boundary and pass it into the
model as a dependency. Successful Jira fetches (on startup and manual
reloads) now schedule a separate cache write, keeping caching failures
independent from displaying the fetched issues.

Implements part of https://github.com/dhth/punchout/issues/127.
