### PR TITLE
add ability to use cache on startup

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -155,7 +155,7 @@ func NewRootCommand() (*cobra.Command, error) {
 
 			return ui.RenderUI(db, jiraSvc, issueStore, ui.Options{
 				Jira:              appCfg.Jira.Options,
-				UseCacheOnStartup: true,
+				UseCacheOnStartup: false,
 			})
 		},
 	}

--- a/internal/ui/cmds.go
+++ b/internal/ui/cmds.go
@@ -212,16 +212,38 @@ func updateSyncStatusForEntry(db *sql.DB, entry d.WorklogEntry, index int, fallb
 	}
 }
 
-func (m Model) fetchJIRAIssues() tea.Cmd {
+func (m Model) fetchIssuesFromJIRA() tea.Cmd {
 	return func() tea.Msg {
 		issues, err := m.jiraSvc.GetIssues(m.opts.Jira.JQL)
 		if err != nil {
-			return issuesFetchedFromJIRA{err: err}
+			return issuesLoaded{
+				source: issueSourceJIRA,
+				err:    err,
+			}
 		}
 
-		return issuesFetchedFromJIRA{
+		return issuesLoaded{
 			issues:    issues,
 			fetchedAt: time.Now(),
+			source:    issueSourceJIRA,
+		}
+	}
+}
+
+func (m Model) loadIssuesFromCache() tea.Cmd {
+	return func() tea.Msg {
+		snapshot, err := m.issueStore.Load()
+		if err != nil {
+			return issuesLoaded{
+				source: issueSourceCache,
+				err:    err,
+			}
+		}
+
+		return issuesLoaded{
+			issues:    snapshot.Issues,
+			fetchedAt: snapshot.FetchedAt,
+			source:    issueSourceCache,
 		}
 	}
 }

--- a/internal/ui/handle.go
+++ b/internal/ui/handle.go
@@ -265,7 +265,7 @@ func (m *Model) getCmdToReloadData() tea.Cmd {
 	case issueListView:
 		m.issueList.Title = "fetching..."
 		m.issueList.Styles.Title = m.issueList.Styles.Title.Background(lipgloss.Color(issueListUnfetchedColor))
-		cmd = m.fetchJIRAIssues()
+		cmd = m.fetchIssuesFromJIRA()
 	case wLView:
 		cmd = fetchUnsyncedWorkLogs(m.db)
 		m.worklogList.ResetSelected()
@@ -530,8 +530,12 @@ func (m *Model) handleWindowResizing(msg tea.WindowSizeMsg) {
 	}
 }
 
-func (m *Model) handleIssuesFetchedFromJIRAMsg(msg issuesFetchedFromJIRA) tea.Cmd {
+func (m *Model) handleIssuesLoadedMsg(msg issuesLoaded) tea.Cmd {
 	if msg.err != nil {
+		if msg.source == issueSourceCache {
+			return m.fetchIssuesFromJIRA()
+		}
+
 		m.message = fmt.Sprintf("error fetching issues from JIRA: %s", msg.err.Error())
 		m.messages = append(m.messages, m.message)
 		m.issueList.Title = "Failure"
@@ -551,13 +555,15 @@ func (m *Model) handleIssuesFetchedFromJIRAMsg(msg issuesFetchedFromJIRA) tea.Cm
 	m.issueList.Styles.Title = m.issueList.Styles.Title.Background(lipgloss.Color(issueListColor))
 	m.issuesFetched = true
 
-	return tea.Batch(
-		fetchActiveStatus(m.db, 0),
-		m.saveIssuesToCache(issuecache.Snapshot{
+	cmds := []tea.Cmd{fetchActiveStatus(m.db, 0)}
+	if msg.source == issueSourceJIRA {
+		cmds = append(cmds, m.saveIssuesToCache(issuecache.Snapshot{
 			Issues:    msg.issues,
 			FetchedAt: msg.fetchedAt,
-		}),
-	)
+		}))
+	}
+
+	return tea.Batch(cmds...)
 }
 
 func (m *Model) handleIssuesSavedToCacheMsg(msg issuesSavedToCache) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -100,10 +100,13 @@ type Model struct {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(
-		hideHelp(time.Minute*1),
-		m.fetchJIRAIssues(),
-		fetchUnsyncedWorkLogs(m.db),
-		fetchSyncedWorkLogs(m.db),
-	)
+	cmds := []tea.Cmd{hideHelp(time.Minute * 1)}
+	if m.opts.UseCacheOnStartup {
+		cmds = append(cmds, m.loadIssuesFromCache())
+	} else {
+		cmds = append(cmds, m.fetchIssuesFromJIRA())
+	}
+	cmds = append(cmds, fetchUnsyncedWorkLogs(m.db), fetchSyncedWorkLogs(m.db))
+
+	return tea.Batch(cmds...)
 }

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -69,9 +69,17 @@ type wLSyncUpdatedInDB struct {
 	err   error
 }
 
-type issuesFetchedFromJIRA struct {
+type issueSource uint
+
+const (
+	issueSourceJIRA issueSource = iota
+	issueSourceCache
+)
+
+type issuesLoaded struct {
 	issues    []d.Issue
 	fetchedAt time.Time
+	source    issueSource
 	err       error
 }
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -227,8 +227,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		m.handleWindowResizing(msg)
-	case issuesFetchedFromJIRA:
-		handleCmd := m.handleIssuesFetchedFromJIRAMsg(msg)
+	case issuesLoaded:
+		handleCmd := m.handleIssuesLoadedMsg(msg)
 		if handleCmd != nil {
 			cmds = append(cmds, handleCmd)
 		}


### PR DESCRIPTION
Add a cache-first startup path to the TUI while keeping manual reloads
live. Cache misses or invalid snapshots fall back to Jira, and
successful Jira results continue to refresh the cache.

A shared source-aware result keeps issue-list handling consistent while
preserving the different follow-up behavior for cached and live data.

Implements part of https://github.com/dhth/punchout/issues/127.