### PR TITLE
add CLI flag for using cache on startup

### DIFF
--- a/internal/cmd/format.go
+++ b/internal/cmd/format.go
@@ -11,6 +11,7 @@ import (
 func formatTUIConfig(configPath, dbPath string, cfg config.Config) string {
 	var result strings.Builder
 	writePathsSection(&result, configPath, dbPath)
+	writeTUISection(&result, cfg.TUI)
 	writeJiraSection(&result, cfg.Jira)
 	return result.String()
 }
@@ -27,6 +28,11 @@ func writePathsSection(result *strings.Builder, configPath, dbPath string) {
 	fmt.Fprint(result, "[Paths]\n")
 	writeField(result, "Config File Path", configPath)
 	writeField(result, "DB File Path", dbPath)
+}
+
+func writeTUISection(result *strings.Builder, cfg config.TUIConfig) {
+	fmt.Fprint(result, "\n[TUI]\n")
+	writeField(result, "Use Cache On Startup", cfg.UseCacheOnStartup)
 }
 
 func writeJiraSection(result *strings.Builder, cfg config.JiraConfig) {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -53,6 +53,7 @@ func NewRootCommand() (*cobra.Command, error) {
 		flagJiraUsername         string
 		flagJQL                  string
 		flagListConfig           bool
+		flagUseCacheOnStartup    bool
 
 		flagMcpTransportStr string
 		flagMcpServerPort   uint
@@ -125,6 +126,10 @@ func NewRootCommand() (*cobra.Command, error) {
 				overrides.Jira.FallbackComment = &flagFallbackComment
 			}
 
+			if cmd.Flags().Changed("use-cache-on-startup") {
+				overrides.TUI.UseCacheOnStartup = &flagUseCacheOnStartup
+			}
+
 			appCfg, err = config.Load(configPathFull, overrides)
 			return err
 		},
@@ -155,7 +160,7 @@ func NewRootCommand() (*cobra.Command, error) {
 
 			return ui.RenderUI(db, jiraSvc, issueStore, ui.Options{
 				Jira:              appCfg.Jira.Options,
-				UseCacheOnStartup: false,
+				UseCacheOnStartup: appCfg.TUI.UseCacheOnStartup,
 			})
 		},
 	}
@@ -231,6 +236,7 @@ func NewRootCommand() (*cobra.Command, error) {
 	rootCmd.PersistentFlags().StringVarP(&flagFallbackComment, "fallback-comment", "", "", "fallback comment to use for worklog entries")
 	rootCmd.PersistentFlags().StringVarP(&flagJiraTimeDeltaMinsStr, "jira-time-delta-mins", "", "", "time delta (in minutes) between your timezone and the timezone of the JIRA server; can be +/-")
 	rootCmd.PersistentFlags().BoolVarP(&flagListConfig, "list-config", "", false, "print the config that punchout will use")
+	rootCmd.Flags().BoolVarP(&flagUseCacheOnStartup, "use-cache-on-startup", "", false, "load JIRA issues from the local cache on startup")
 
 	mcpServeCmd.Flags().StringVarP(&flagMcpTransportStr, "transport", "t", "stdio", "transport to use (possible values: [stdio, http])")
 	mcpServeCmd.Flags().UintVarP(&flagMcpServerPort, "http-port", "p", 18899, "port to use (when transport is http)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,11 @@ var (
 
 type Config struct {
 	Jira JiraConfig
+	TUI  TUIConfig
+}
+
+type TUIConfig struct {
+	UseCacheOnStartup bool
 }
 
 type JiraConfig struct {
@@ -62,6 +67,11 @@ func (OnPremiseInstallation) isJiraInstallation() {}
 
 type Overrides struct {
 	Jira JiraOverrides
+	TUI  TUIOverrides
+}
+
+type TUIOverrides struct {
+	UseCacheOnStartup *bool
 }
 
 type JiraOverrides struct {
@@ -76,6 +86,11 @@ type JiraOverrides struct {
 
 type fileConfig struct {
 	Jira fileJiraConfig `toml:"jira"`
+	TUI  fileTUIConfig  `toml:"tui"`
+}
+
+type fileTUIConfig struct {
+	UseCacheOnStartup bool `toml:"use_cache_on_startup"`
 }
 
 type fileJiraConfig struct {
@@ -112,7 +127,12 @@ func decodeAndResolve(reader io.Reader, overrides Overrides) (Config, error) {
 		return Config{}, fmt.Errorf("%w: %s", ErrInvalidConfig, err.Error())
 	}
 
-	return Config{Jira: jiraCfg}, nil
+	return Config{
+		Jira: jiraCfg,
+		TUI: TUIConfig{
+			UseCacheOnStartup: effectiveCfg.TUI.UseCacheOnStartup,
+		},
+	}, nil
 }
 
 func withOverrides(cfg fileConfig, overrides Overrides) fileConfig {
@@ -138,6 +158,9 @@ func withOverrides(cfg fileConfig, overrides Overrides) fileConfig {
 	}
 	if overrides.Jira.FallbackComment != nil {
 		result.Jira.FallbackComment = overrides.Jira.FallbackComment
+	}
+	if overrides.TUI.UseCacheOnStartup != nil {
+		result.TUI.UseCacheOnStartup = *overrides.TUI.UseCacheOnStartup
 	}
 
 	return result

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,6 +117,32 @@ jira_token = "minimal-token"
 					},
 				},
 			},
+			{
+				name: "when TUI cache startup is enabled",
+				input: `
+[jira]
+jira_url = "https://jira.company.com"
+jql = "project = PUNCH"
+jira_token = "token"
+
+[tui]
+use_cache_on_startup = true
+`,
+				expected: Config{
+					Jira: JiraConfig{
+						Options: JiraOptions{
+							JQL: "project = PUNCH",
+						},
+						Installation: OnPremiseInstallation{
+							URL:   "https://jira.company.com",
+							Token: "token",
+						},
+					},
+					TUI: TUIConfig{
+						UseCacheOnStartup: true,
+					},
+				},
+			},
 		}
 
 		for _, tt := range tests {
@@ -132,6 +158,8 @@ jira_token = "minimal-token"
 		jqlOverride := "project = OVERRIDDEN"
 		timeDeltaMinsOverride := 0
 		fallbackCommentOverride := "overridden work"
+		useCacheOnStartupOverride := true
+		dontUseCacheOnStartupOverride := false
 		cloudInstallationType := JiraInstallationTypeCloud
 		jiraURLOverride := "https://overridden.jira.company.com"
 		jiraTokenOverride := "overridden-token"
@@ -206,6 +234,65 @@ fallback_comment = "original work"
 							URL:      "https://overridden.jira.company.com",
 							Username: "overridden-user@example.com",
 							Token:    "overridden-token",
+						},
+					},
+				},
+			},
+			{
+				name: "when TUI cache startup is enabled by an override",
+				input: `
+[jira]
+jira_url = "https://jira.company.com"
+jql = "project = PUNCH"
+jira_token = "token"
+
+[tui]
+use_cache_on_startup = false
+`,
+				overrides: Overrides{
+					TUI: TUIOverrides{
+						UseCacheOnStartup: &useCacheOnStartupOverride,
+					},
+				},
+				expected: Config{
+					Jira: JiraConfig{
+						Options: JiraOptions{
+							JQL: "project = PUNCH",
+						},
+						Installation: OnPremiseInstallation{
+							URL:   "https://jira.company.com",
+							Token: "token",
+						},
+					},
+					TUI: TUIConfig{
+						UseCacheOnStartup: true,
+					},
+				},
+			},
+			{
+				name: "when TUI cache startup is explicitly disabled by an override",
+				input: `
+[jira]
+jira_url = "https://jira.company.com"
+jql = "project = PUNCH"
+jira_token = "token"
+
+[tui]
+use_cache_on_startup = true
+`,
+				overrides: Overrides{
+					TUI: TUIOverrides{
+						UseCacheOnStartup: &dontUseCacheOnStartupOverride,
+					},
+				},
+				expected: Config{
+					Jira: JiraConfig{
+						Options: JiraOptions{
+							JQL: "project = PUNCH",
+						},
+						Installation: OnPremiseInstallation{
+							URL:   "https://jira.company.com",
+							Token: "token",
 						},
 					},
 				},

--- a/tests/cli/__snapshots__/TestMainCmd_cache_startup_can_be_enabled_by_flag_1.snap
+++ b/tests/cli/__snapshots__/TestMainCmd_cache_startup_can_be_enabled_by_flag_1.snap
@@ -6,7 +6,7 @@ Config File Path                        config/good.toml
 DB File Path                            db.db
 
 [TUI]
-Use Cache On Startup                    false
+Use Cache On Startup                    true
 
 [JIRA]
 JIRA Installation Type                  onpremise
@@ -14,7 +14,7 @@ JIRA URL                                https://jira.company.com
 JIRA Token                              [REDACTED]
 JQL                                     project = BLAH AND sprint in openSprints ()
 JIRA Time Delta Mins                    300
-Fallback Comment                        test
+Fallback Comment                        work
 
 ----- stderr -----
 

--- a/tests/cli/__snapshots__/TestMainCmd_cache_startup_can_be_enabled_from_config_1.snap
+++ b/tests/cli/__snapshots__/TestMainCmd_cache_startup_can_be_enabled_from_config_1.snap
@@ -2,11 +2,11 @@ success: true
 exit_code: 0
 ----- stdout -----
 [Paths]
-Config File Path                        config/good.toml
+Config File Path                        config/cache-enabled.toml
 DB File Path                            db.db
 
 [TUI]
-Use Cache On Startup                    false
+Use Cache On Startup                    true
 
 [JIRA]
 JIRA Installation Type                  onpremise
@@ -14,7 +14,7 @@ JIRA URL                                https://jira.company.com
 JIRA Token                              [REDACTED]
 JQL                                     project = BLAH AND sprint in openSprints ()
 JIRA Time Delta Mins                    300
-Fallback Comment                        test
+Fallback Comment                        work
 
 ----- stderr -----
 

--- a/tests/cli/__snapshots__/TestMainCmd_cache_startup_can_be_explicitly_disabled_by_flag_1.snap
+++ b/tests/cli/__snapshots__/TestMainCmd_cache_startup_can_be_explicitly_disabled_by_flag_1.snap
@@ -2,7 +2,7 @@ success: true
 exit_code: 0
 ----- stdout -----
 [Paths]
-Config File Path                        config/good.toml
+Config File Path                        config/cache-enabled.toml
 DB File Path                            db.db
 
 [TUI]
@@ -14,7 +14,7 @@ JIRA URL                                https://jira.company.com
 JIRA Token                              [REDACTED]
 JQL                                     project = BLAH AND sprint in openSprints ()
 JIRA Time Delta Mins                    300
-Fallback Comment                        test
+Fallback Comment                        work
 
 ----- stderr -----
 

--- a/tests/cli/__snapshots__/TestMainCmd_cloud_setup_works_1.snap
+++ b/tests/cli/__snapshots__/TestMainCmd_cloud_setup_works_1.snap
@@ -5,6 +5,9 @@ exit_code: 0
 Config File Path                        config/good.toml
 DB File Path                            db.db
 
+[TUI]
+Use Cache On Startup                    false
+
 [JIRA]
 JIRA Installation Type                  cloud
 JIRA URL                                https://jira.company.com

--- a/tests/cli/__snapshots__/TestMainCmd_flags_override_config_1.snap
+++ b/tests/cli/__snapshots__/TestMainCmd_flags_override_config_1.snap
@@ -5,6 +5,9 @@ exit_code: 0
 Config File Path                        config/good.toml
 DB File Path                            db.db
 
+[TUI]
+Use Cache On Startup                    false
+
 [JIRA]
 JIRA Installation Type                  onpremise
 JIRA URL                                https://overridden.company.com

--- a/tests/cli/__snapshots__/TestMainCmd_help_flag_works_1.snap
+++ b/tests/cli/__snapshots__/TestMainCmd_help_flag_works_1.snap
@@ -23,6 +23,7 @@ Flags:
       --jira-username string            username for authentication (for cloud installation)
       --jql string                      JQL to use to query issues
       --list-config                     print the config that punchout will use
+      --use-cache-on-startup            load JIRA issues from the local cache on startup
 
 Use "punchout [command] --help" for more information about a command.
 

--- a/tests/cli/__snapshots__/TestMainCmd_installation_type_falls_back_to_onpremise_1.snap
+++ b/tests/cli/__snapshots__/TestMainCmd_installation_type_falls_back_to_onpremise_1.snap
@@ -5,6 +5,9 @@ exit_code: 0
 Config File Path                        config/good.toml
 DB File Path                            db.db
 
+[TUI]
+Use Cache On Startup                    false
+
 [JIRA]
 JIRA Installation Type                  onpremise
 JIRA URL                                https://jira.company.com

--- a/tests/cli/__snapshots__/TestMainCmd_onpremise_setup_works_1.snap
+++ b/tests/cli/__snapshots__/TestMainCmd_onpremise_setup_works_1.snap
@@ -5,6 +5,9 @@ exit_code: 0
 Config File Path                        config/good.toml
 DB File Path                            db.db
 
+[TUI]
+Use Cache On Startup                    false
+
 [JIRA]
 JIRA Installation Type                  onpremise
 JIRA URL                                https://jira.company.com

--- a/tests/cli/config/cache-enabled.toml
+++ b/tests/cli/config/cache-enabled.toml
@@ -1,0 +1,9 @@
+[jira]
+jira_url = "https://jira.company.com"
+jira_token = "XXX"
+jql = "project = BLAH AND sprint in openSprints ()"
+jira_time_delta_mins = 300
+fallback_comment = "work"
+
+[tui]
+use_cache_on_startup = true

--- a/tests/cli/main_cmd_test.go
+++ b/tests/cli/main_cmd_test.go
@@ -122,6 +122,56 @@ func TestMainCmd(t *testing.T) {
 		snaps.MatchStandaloneSnapshot(t, result)
 	})
 
+	t.Run("cache startup can be enabled from config", func(t *testing.T) {
+		// GIVEN
+		args := []string{
+			"--config-file-path", "config/cache-enabled.toml",
+			"--db-path", "db.db",
+			"--list-config",
+		}
+
+		// WHEN
+		result, err := fx.runCmd(args)
+
+		// THEN
+		require.NoError(t, err)
+		snaps.MatchStandaloneSnapshot(t, result)
+	})
+
+	t.Run("cache startup can be enabled by flag", func(t *testing.T) {
+		// GIVEN
+		args := []string{
+			"--config-file-path", "config/good.toml",
+			"--db-path", "db.db",
+			"--use-cache-on-startup",
+			"--list-config",
+		}
+
+		// WHEN
+		result, err := fx.runCmd(args)
+
+		// THEN
+		require.NoError(t, err)
+		snaps.MatchStandaloneSnapshot(t, result)
+	})
+
+	t.Run("cache startup can be explicitly disabled by flag", func(t *testing.T) {
+		// GIVEN
+		args := []string{
+			"--config-file-path", "config/cache-enabled.toml",
+			"--db-path", "db.db",
+			"--use-cache-on-startup=false",
+			"--list-config",
+		}
+
+		// WHEN
+		result, err := fx.runCmd(args)
+
+		// THEN
+		require.NoError(t, err)
+		snaps.MatchStandaloneSnapshot(t, result)
+	})
+
 	// FAILURES
 	t.Run("providing incorrect installation type fails", func(t *testing.T) {
 		// GIVEN


### PR DESCRIPTION
Add an opt-in TUI setting for loading Jira issues from the cache at
startup. The setting is added to the output of `--list-config`.
