### PR TITLE
show user messages after cache load failure

### DIFF
--- a/internal/ui/cmds.go
+++ b/internal/ui/cmds.go
@@ -212,20 +212,22 @@ func updateSyncStatusForEntry(db *sql.DB, entry d.WorklogEntry, index int, fallb
 	}
 }
 
-func (m Model) fetchIssuesFromJIRA() tea.Cmd {
+func (m Model) fetchIssuesFromJIRA(afterCacheLoadFailure bool) tea.Cmd {
 	return func() tea.Msg {
 		issues, err := m.jiraSvc.GetIssues(m.opts.Jira.JQL)
 		if err != nil {
 			return issuesLoaded{
-				source: issueSourceJIRA,
-				err:    err,
+				source:                issueSourceJIRA,
+				afterCacheLoadFailure: afterCacheLoadFailure,
+				err:                   err,
 			}
 		}
 
 		return issuesLoaded{
-			issues:    issues,
-			fetchedAt: time.Now().UTC(),
-			source:    issueSourceJIRA,
+			issues:                issues,
+			fetchedAt:             time.Now().UTC(),
+			source:                issueSourceJIRA,
+			afterCacheLoadFailure: afterCacheLoadFailure,
 		}
 	}
 }

--- a/internal/ui/handle.go
+++ b/internal/ui/handle.go
@@ -266,7 +266,7 @@ func (m *Model) getCmdToReloadData() tea.Cmd {
 	case issueListView:
 		m.issueList.Title = "fetching..."
 		m.issueList.Styles.Title = m.issueList.Styles.Title.Background(lipgloss.Color(issueListUnfetchedColor))
-		cmd = m.fetchIssuesFromJIRA()
+		cmd = m.fetchIssuesFromJIRA(false)
 	case wLView:
 		cmd = fetchUnsyncedWorkLogs(m.db)
 		m.worklogList.ResetSelected()
@@ -528,10 +528,17 @@ func (m *Model) handleWindowResizing(msg tea.WindowSizeMsg) {
 func (m *Model) handleIssuesLoadedMsg(msg issuesLoaded) []tea.Cmd {
 	if msg.err != nil {
 		if msg.source == issueSourceCache {
-			return []tea.Cmd{m.fetchIssuesFromJIRA()}
+			return []tea.Cmd{m.fetchIssuesFromJIRA(true)}
 		}
 
-		m.setErrorMsg(fmt.Sprintf("error fetching issues from JIRA: %s", msg.err.Error()))
+		var errorMsg string
+		if msg.afterCacheLoadFailure {
+			errorMsg = fmt.Sprintf("cache unavailable and couldn't fetch issues from JIRA: %s", msg.err.Error())
+		} else {
+			errorMsg = fmt.Sprintf("couldn't fetch issues from JIRA: %s", msg.err.Error())
+		}
+
+		m.setErrorMsg(errorMsg)
 		m.issueList.Title = "Failure"
 		m.issueList.Styles.Title = m.issueList.Styles.Title.Background(lipgloss.Color(failureColor))
 		return nil
@@ -549,26 +556,26 @@ func (m *Model) handleIssuesLoadedMsg(msg issuesLoaded) []tea.Cmd {
 	m.issueList.Styles.Title = m.issueList.Styles.Title.Background(lipgloss.Color(issueListColor))
 	m.issuesFetched = true
 
-	if msg.source == issueSourceCache {
-		if len(msg.issues) > 0 {
-			secondsSinceFetch := int(time.Since(msg.fetchedAt).Seconds())
-			if secondsSinceFetch < 0 {
-				secondsSinceFetch = 0
-			}
-
-			if secondsSinceFetch == 0 {
-				m.setInfoMsg("issues loaded from cache")
-			} else {
-				fetchedAgo := utils.HumanizeDuration(secondsSinceFetch)
-				m.setInfoMsg(fmt.Sprintf("issues loaded from cache • fetched %s ago", fetchedAgo))
-			}
-		} else {
-			m.setInfoMsg("no issues found in cache")
-		}
-	}
-
 	cmds := []tea.Cmd{fetchActiveStatus(m.db, 0)}
-	if msg.source == issueSourceJIRA {
+	switch msg.source {
+	case issueSourceCache:
+		if len(msg.issues) == 0 {
+			m.setInfoMsg("no issues found in cache")
+			break
+		}
+
+		secondsSinceFetch := int(time.Since(msg.fetchedAt).Seconds())
+		if secondsSinceFetch <= 0 {
+			m.setInfoMsg("issues loaded from cache")
+		} else {
+			fetchedAgo := utils.HumanizeDuration(secondsSinceFetch)
+			m.setInfoMsg(fmt.Sprintf("issues loaded from cache • fetched %s ago", fetchedAgo))
+		}
+	case issueSourceJIRA:
+		if msg.afterCacheLoadFailure {
+			m.setInfoMsg("cache unavailable • issues fetched from JIRA")
+		}
+
 		cmds = append(cmds, m.saveIssuesToCache(issuecache.Snapshot{
 			Issues:    msg.issues,
 			FetchedAt: msg.fetchedAt,

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -151,7 +151,7 @@ func (m Model) Init() tea.Cmd {
 	if m.opts.UseCacheOnStartup {
 		cmds = append(cmds, m.loadIssuesFromCache())
 	} else {
-		cmds = append(cmds, m.fetchIssuesFromJIRA())
+		cmds = append(cmds, m.fetchIssuesFromJIRA(false))
 	}
 	cmds = append(cmds, fetchUnsyncedWorkLogs(m.db), fetchSyncedWorkLogs(m.db))
 

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -81,10 +81,11 @@ const (
 )
 
 type issuesLoaded struct {
-	issues    []d.Issue
-	fetchedAt time.Time
-	source    issueSource
-	err       error
+	issues                []d.Issue
+	fetchedAt             time.Time
+	source                issueSource
+	afterCacheLoadFailure bool
+	err                   error
 }
 
 type issuesSavedToCache struct {


### PR DESCRIPTION
Carry cache-load fallback context through asynchronous Jira fetches so
the TUI can distinguish normal requests from cache bootstrap attempts.

Report when Jira successfully recovers from an unavailable cache, and
when neither source can provide issues. Normal startup and manual reload
behavior remain unchanged.
